### PR TITLE
Sostituisci ’ con '

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # -- PROJECT Variables ----------------------------------------------------
-settings_project_name = "Linee guida dell’indice dei domicili digitali delle pubbliche amministrazioni e dei gestori di pubblici servizi"
+settings_project_name = "Linee guida dell'indice dei domicili digitali delle pubbliche amministrazioni e dei gestori di pubblici servizi"
 settings_copyright_copyleft = 'AgID'
 settings_editor_name = 'AgID'
 settings_doc_version = 'version: latest'


### PR DESCRIPTION
Nel titolo del documento non sono ammessi caratteri "speciali".
Gli apostrofi devono essere sostituiti da indici.
Nel nuovo Docs Italia non dovrebbe esserci questo tipo di problema.